### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/re2/make_unicode_casefold.py
+++ b/re2/make_unicode_casefold.py
@@ -114,10 +114,10 @@ def main():
   seen = {}
   for c in casegroups:
     if len(c) > MaxCasefoldGroup:
-      raise unicode.Error("casefold group too long: %s" % (c,))
+      raise unicode.Error("casefold group too long: {0!s}".format(c))
     for i in range(len(c)):
       if c[i-1] in seen:
-        raise unicode.Error("bad casegroups %d -> %d" % (c[i-1], c[i]))
+        raise unicode.Error("bad casegroups {0:d} -> {1:d}".format(c[i-1], c[i]))
       seen[c[i-1]] = True
       foldpairs.append([c[i-1], c[i]])
 
@@ -130,12 +130,12 @@ def main():
   def printpairs(name, foldpairs):
     foldpairs.sort()
     foldranges = _MakeRanges(foldpairs)
-    print "// %d groups, %d pairs, %d ranges" % (len(casegroups), len(foldpairs), len(foldranges))
-    print "const CaseFold unicode_%s[] = {" % (name,)
+    print "// {0:d} groups, {1:d} pairs, {2:d} ranges".format(len(casegroups), len(foldpairs), len(foldranges))
+    print "const CaseFold unicode_{0!s}[] = {{".format(name)
     for lo, hi, delta in foldranges:
-      print "\t{ %d, %d, %s }," % (lo, hi, delta)
+      print "\t{{ {0:d}, {1:d}, {2!s} }},".format(lo, hi, delta)
     print "};"
-    print "const int num_unicode_%s = %d;" % (name, len(foldranges),)
+    print "const int num_unicode_{0!s} = {1:d};".format(name, len(foldranges))
     print ""
 
   print _header

--- a/re2/make_unicode_groups.py
+++ b/re2/make_unicode_groups.py
@@ -41,9 +41,9 @@ def MakeRanges(codes):
 
 def PrintRanges(type, name, ranges):
   """Print the ranges as an array of type named name."""
-  print "static const %s %s[] = {" % (type, name,)
+  print "static const {0!s} {1!s}[] = {{".format(type, name)
   for lo, hi in ranges:
-    print "\t{ %d, %d }," % (lo, hi)
+    print "\t{{ {0:d}, {1:d} }},".format(lo, hi)
   print "};"
 
 # def PrintCodes(type, name, codes):
@@ -72,7 +72,7 @@ def PrintGroup(name, codes):
   n16 += len(range16)
   n32 += len(range32)
 
-  ugroup = "{ \"%s\", +1" % (name,)
+  ugroup = "{{ \"{0!s}\", +1".format(name)
   # if len(code16) > 0:
   #   PrintCodes("uint16", name+"_code16", code16)
   #   ugroup += ", %s_code16, %d" % (name, len(code16))
@@ -80,12 +80,12 @@ def PrintGroup(name, codes):
   #   ugroup += ", 0, 0"
   if len(range16) > 0:
     PrintRanges("URange16", name+"_range16", range16)
-    ugroup += ", %s_range16, %d" % (name, len(range16))
+    ugroup += ", {0!s}_range16, {1:d}".format(name, len(range16))
   else:
     ugroup += ", 0, 0"
   if len(range32) > 0:
     PrintRanges("URange32", name+"_range32", range32)
-    ugroup += ", %s_range32, %d" % (name, len(range32))
+    ugroup += ", {0!s}_range32, {1:d}".format(name, len(range32))
   else:
     ugroup += ", 0, 0"
   ugroup += " }"
@@ -98,13 +98,13 @@ def main():
     ugroups.append(PrintGroup(name, codes))
   for name, codes in unicode.Scripts().iteritems():
     ugroups.append(PrintGroup(name, codes))
-  print "// %d 16-bit ranges, %d 32-bit ranges" % (n16, n32)
+  print "// {0:d} 16-bit ranges, {1:d} 32-bit ranges".format(n16, n32)
   print "const UGroup unicode_groups[] = {";
   ugroups.sort()
   for ug in ugroups:
-    print "\t%s," % (ug,)
+    print "\t{0!s},".format(ug)
   print "};"
-  print "const int num_unicode_groups = %d;" % (len(ugroups),)
+  print "const int num_unicode_groups = {0:d};".format(len(ugroups))
   print _trailer
 
 if __name__ == '__main__':

--- a/re2/unicode.py
+++ b/re2/unicode.py
@@ -41,7 +41,7 @@ def _UInt(s):
   except ValueError:
     v = -1
   if len(s) < 4 or len(s) > 6 or v < 0 or v > _RUNE_MAX:
-    raise InputError("invalid Unicode value %s" % (s,))
+    raise InputError("invalid Unicode value {0!s}".format(s))
   return v
 
 
@@ -68,7 +68,7 @@ def _URange(s):
     hi = _UInt(a[1])
     if lo < hi:
       return range(lo, hi + 1)
-  raise InputError("invalid Unicode range %s" % (s,))
+  raise InputError("invalid Unicode range {0!s}".format(s))
 
 
 def _UStr(v):
@@ -86,8 +86,8 @@ def _UStr(v):
     InputError: the argument is not a valid Unicode value.
   """
   if v < 0 or v > _RUNE_MAX:
-    raise InputError("invalid Unicode value %s" % (v,))
-  return "0x%04X" % (v,)
+    raise InputError("invalid Unicode value {0!s}".format(v))
+  return "0x{0:04X}".format(v)
 
 
 def _ParseContinue(s):
@@ -145,7 +145,7 @@ def ReadUnicodeTable(filename, nfields, doline):
   """
 
   if nfields < 2:
-    raise InputError("invalid number of fields %d" % (nfields,))
+    raise InputError("invalid number of fields {0:d}".format(nfields))
 
   if type(filename) == str:
     if filename.startswith("http://"):
@@ -173,8 +173,7 @@ def ReadUnicodeTable(filename, nfields, doline):
       # Must have the expected number of fields.
       fields = [s.strip() for s in line.split(";")]
       if len(fields) != nfields:
-        raise InputError("wrong number of fields %d %d - %s" %
-                         (len(fields), nfields, line))
+        raise InputError("wrong number of fields {0:d} {1:d} - {2!s}".format(len(fields), nfields, line))
 
       # The Unicode text files have two different ways
       # to list a Unicode range.  Either the first field is
@@ -189,12 +188,11 @@ def ReadUnicodeTable(filename, nfields, doline):
         # this one had better give the Last one.
         if (len(codes) != 1 or codes[0] <= first or
             cont != "Last" or name != expect_last):
-          raise InputError("expected Last line for %s" %
-                           (expect_last,))
+          raise InputError("expected Last line for {0!s}".format(expect_last))
         codes = range(first, codes[0] + 1)
         first = None
         expect_last = None
-        fields[0] = "%04X..%04X" % (codes[0], codes[-1])
+        fields[0] = "{0:04X}..{1:04X}".format(codes[0], codes[-1])
         fields[1] = name
       elif cont == "First":
         # Otherwise, if this is the First code in a range,
@@ -208,12 +206,11 @@ def ReadUnicodeTable(filename, nfields, doline):
       doline(codes, fields)
 
     except Exception, e:
-      print "%s:%d: %s" % (filename, lineno, e)
+      print "{0!s}:{1:d}: {2!s}".format(filename, lineno, e)
       raise
 
   if expect_last is not None:
-    raise InputError("expected Last line for %s; got EOF" %
-                     (expect_last,))
+    raise InputError("expected Last line for {0!s}; got EOF".format(expect_last))
 
 
 def CaseGroups(unicode_dir=_UNICODE_DIR):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:re2?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:re2?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
